### PR TITLE
Don't force WebGL 1

### DIFF
--- a/scripts/build.hxml
+++ b/scripts/build.hxml
@@ -32,7 +32,7 @@
 -D tools
 -D commonjs
 -D howlerjs
--D webgl1
+-D webgl
 --macro AS3ExternsGenerator.generate({outputPath: "../lib", includedPackages: ["openfl"], allowedPackageReferences: [], renameSymbols: ["openfl.VectorData", "openfl.Vector", "openfl.utils.ByteArrayData", "openfl.utils.ByteArray", "lime.app.Future", "openfl.utils.Future"]})
 --macro TSExternsGenerator.generate({outputPath: "../lib", includedPackages: ["openfl"], allowedPackageReferences: [], renameSymbols: ["openfl.VectorData", "openfl.Vector", "openfl.utils.ByteArrayData", "openfl.utils.ByteArray", "lime.app.Future", "openfl.utils.Future"]})
 --no-inline


### PR DESCRIPTION
Passing `-D webgl` makes lime attempt WebGL 2, then fallback to WebGL 1, however passing `-D webgl1` makes lime only use WebGL 1 and never try to use 2  
I see no reason why not to try using WebGL2 before WebGL 1   
See:
https://github.com/openfl/lime/blob/964ad6d2650984a11b5828ea92e573ffa2cd2fbe/src/lime/_internal/backend/html5/HTML5Window.hx#L312-L319